### PR TITLE
Add opus audio file mimetype symlink

### DIFF
--- a/links/scalable/mimetypes/audio-x-opus+ogg.svg
+++ b/links/scalable/mimetypes/audio-x-opus+ogg.svg
@@ -1,0 +1,1 @@
+audio-x-generic.svg


### PR DESCRIPTION
This fixes `.opus` files showing only a 16px symbolic monochrome speaker icon instead of the proper scalable file mimetype icon.