### PR TITLE
Feature: Custom color variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Usage:  `./install.sh`  **[OPTIONS...]** **[COLOR VARIANTS...]**
 | purple          | Purple color folder version           |
 | red             | Red color folder version              |
 | yellow          | Yellow color folder version           |
+| teal            | Teal color folder version             |
+| (rrggbb)        | Custom color folder version<br>Enter as valid rgb hexadecimal code |
 
 By default, only **the standard one** is selected.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage:  `./install.sh`  **[OPTIONS...]** **[COLOR VARIANTS...]**
 | red             | Red color folder version              |
 | yellow          | Yellow color folder version           |
 | teal            | Teal color folder version             |
-| (rrggbb)        | Custom color folder version<br>Enter as valid rgb hexadecimal code |
+| (rrggbb)        | Custom color folder version<br>Enter as valid rgb hexadecimal code<br>You can only define one at a time |
 
 By default, only **the standard one** is selected.
 

--- a/install.sh
+++ b/install.sh
@@ -210,6 +210,13 @@ install_theme() {
   local brightprefix=""
   [ -n "$bright" ] && brightprefix="-$bright"
 
+  local THEME_NAME="${NAME}${colorprefix}${brightprefix}"
+  local THEME_DIR="${DEST_DIR}/${THEME_NAME}"
+
+  local TMP_DIR="${THEME_DIR}.tmp.$$"
+  safe_rm_dir "${THEME_DIR}.tmp*"
+  ensure_dir "${TMP_DIR}"
+
   case "$color" in
     standard)
       theme_color='#198ee6' ;;
@@ -232,15 +239,7 @@ install_theme() {
     *)
       # Valid hex color code
       theme_color="#${color}"
-      colorprefix="-custom" ;;
   esac
-
-  local THEME_NAME="${NAME}${colorprefix}${brightprefix}"
-  local THEME_DIR="${DEST_DIR}/${THEME_NAME}"
-
-  local TMP_DIR="${THEME_DIR}.tmp.$$"
-  safe_rm_dir "${THEME_DIR}.tmp*"
-  ensure_dir "${TMP_DIR}"
 
   echo "Installing '${THEME_NAME}'..."
 

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,8 @@ COLOR VARIANTS:
   red                      Red color folder version
   yellow                   Yellow color folder version
   teal                     Teal color folder version
+  (rrggbb)                 Custom color folder version
+                           Enter as valid rgb hexadecimal code
 
   By default, only the standard one is selected.
 EOF

--- a/install.sh
+++ b/install.sh
@@ -208,13 +208,6 @@ install_theme() {
   local brightprefix=""
   [ -n "$bright" ] && brightprefix="-$bright"
 
-  local THEME_NAME="${NAME}${colorprefix}${brightprefix}"
-  local THEME_DIR="${DEST_DIR}/${THEME_NAME}"
-
-  local TMP_DIR="${THEME_DIR}.tmp.$$"
-  safe_rm_dir "${THEME_DIR}.tmp*"
-  ensure_dir "${TMP_DIR}"
-
   case "$color" in
     standard)
       theme_color='#198ee6' ;;
@@ -234,7 +227,18 @@ install_theme() {
       theme_color='#32c8ba' ;;
     grey)
       theme_color='#808080' ;;
+    *)
+      # Valid hex color code
+      theme_color="#${color}"
+      colorprefix="-custom" ;;
   esac
+
+  local THEME_NAME="${NAME}${colorprefix}${brightprefix}"
+  local THEME_DIR="${DEST_DIR}/${THEME_NAME}"
+
+  local TMP_DIR="${THEME_DIR}.tmp.$$"
+  safe_rm_dir "${THEME_DIR}.tmp*"
+  ensure_dir "${TMP_DIR}"
 
   echo "Installing '${THEME_NAME}'..."
 
@@ -340,6 +344,9 @@ while [ $# -gt 0 ]; do
     *)
       if [[ " ${COLOR_VARIANTS[*]} " == *" $1 "* ]]; then
         [[ " ${colors[*]-} " != *" $1 "* ]] && colors+=("$1")
+      # Check if value is a valid rgb hex color code
+      elif [[ "$1" =~ ''^([[:xdigit:]]{6})$ ]]; then
+        colors+=("$1")
       else
         die "Unrecognized installation option '$1'. Try '$0 --help'."
       fi
@@ -373,3 +380,5 @@ for color in "${colors[@]}"; do
 done
 
 echo "Done."
+
+

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,7 @@ COLOR VARIANTS:
   teal                     Teal color folder version
   (rrggbb)                 Custom color folder version
                            Enter as valid rgb hexadecimal code
+                           You can only define one at a time
 
   By default, only the standard one is selected.
 EOF
@@ -210,13 +211,6 @@ install_theme() {
   local brightprefix=""
   [ -n "$bright" ] && brightprefix="-$bright"
 
-  local THEME_NAME="${NAME}${colorprefix}${brightprefix}"
-  local THEME_DIR="${DEST_DIR}/${THEME_NAME}"
-
-  local TMP_DIR="${THEME_DIR}.tmp.$$"
-  safe_rm_dir "${THEME_DIR}.tmp*"
-  ensure_dir "${TMP_DIR}"
-
   case "$color" in
     standard)
       theme_color='#198ee6' ;;
@@ -239,7 +233,15 @@ install_theme() {
     *)
       # Valid hex color code
       theme_color="#${color}"
+      colorprefix="-custom" ;;
   esac
+
+  local THEME_NAME="${NAME}${colorprefix}${brightprefix}"
+  local THEME_DIR="${DEST_DIR}/${THEME_NAME}"
+
+  local TMP_DIR="${THEME_DIR}.tmp.$$"
+  safe_rm_dir "${THEME_DIR}.tmp*"
+  ensure_dir "${TMP_DIR}"
 
   echo "Installing '${THEME_NAME}'..."
 
@@ -335,6 +337,7 @@ install_theme() {
 #==========================
 NAME=""
 colors=()
+custom_color_set=false
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -347,7 +350,11 @@ while [ $# -gt 0 ]; do
         [[ " ${colors[*]-} " != *" $1 "* ]] && colors+=("$1")
       # Check if value is a valid rgb hex color code
       elif [[ "$1" =~ ''^([[:xdigit:]]{6})$ ]]; then
+        # Building multiple custom colors is bad because
+        # they will just overwrite each other
+        $custom_color_set && die "You cannot install multiple themes with custom colors at once."
         colors+=("$1")
+        custom_color_set=true
       else
         die "Unrecognized installation option '$1'. Try '$0 --help'."
       fi

--- a/release_install.sh
+++ b/release_install.sh
@@ -33,6 +33,9 @@ COLOR VARIANTS:
   red                      Red color folder version
   yellow                   Yellow color folder version
   teal                     Teal color folder version
+  (rrggbb)                 Custom color folder version
+                           Enter as valid rgb hexadecimal code
+                           You can only define one at a time
 
   By default, only the standard one is selected.
 EOF
@@ -51,13 +54,8 @@ safe_sed_replace() {
 install_theme() {
   # Appends a dash if the variables are not empty
   if [[ "$1" != "standard" ]]; then
-    local -r colorprefix="-$1"
+    local colorprefix="-$1"
   fi
-
-  local -r brightprefix="${2:+-$2}"
-
-  local -r THEME_NAME="${NAME}${colorprefix}${brightprefix}"
-  local -r THEME_DIR="${DEST_DIR}/${THEME_NAME}"
 
   case "$color" in
     standard)
@@ -78,7 +76,16 @@ install_theme() {
       theme_color='#32c8ba' ;;
     grey)
       theme_color='#808080' ;;
+    *)
+      # Valid hex color code
+      theme_color="#${color}"
+      colorprefix="-custom" ;;
   esac
+
+  local -r brightprefix="${2:+-$2}"
+
+  local -r THEME_NAME="${NAME}${colorprefix}${brightprefix}"
+  local -r THEME_DIR="${DEST_DIR}/${THEME_NAME}"
 
   if [ -d "${THEME_DIR}" ]; then
     rm -r "${THEME_DIR}"
@@ -195,6 +202,8 @@ install_theme() {
   gtk-update-icon-cache "${THEME_DIR}"
 }
 
+custom_color_set=false
+
 while [ $# -gt 0 ]; do
   case "${1}" in
     -a|--all)
@@ -216,6 +225,12 @@ while [ $# -gt 0 ]; do
       # If the argument is a color variant, append it to the colors to be installed
       if [[ " ${COLOR_VARIANTS[*]} " = *" ${1} "* ]] && [[ "${colors[*]}" != *${1}* ]]; then
         colors+=("${1}")
+      elif [[ "${1}" =~ ''^([[:xdigit:]]{6})$ ]]; then
+        # Building multiple custom colors is bad because
+        # they will just overwrite each other
+        $custom_color_set && echo "ERROR: You cannot install multiple themes with custom colors at once." && exit 1
+        colors+=("${1}")
+        custom_color_set=true
       else
         echo "ERROR: Unrecognized installation option '${1}'."
         echo "Try '${0} --help' for more information."


### PR DESCRIPTION
This pull request slightly modifies the install scripts to allow custom color variants in the form of RGB hexadecimal codes (rrggbb) in the `[COLOR VARIANTS]` parameter(s).